### PR TITLE
Add Grafana, Prometheus, n8n, and Sentry

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,8 +23,12 @@ This repository includes Docker Compose configurations for the following service
   - RabbitMQ
 - **Monitoring & Logging**:
   - teleport
+  - Grafana
+  - Prometheus
 - **Other Services**:
   - Jira Atlasian
+  - n8n
+  - Sentry
 
 Each service is preconfigured with sensible defaults, making it easy to get started.
 
@@ -39,7 +43,6 @@ Before using these Docker Compose files, ensure you have the following installed
 - [Docker Compose](https://docs.docker.com/compose/install/)
 
 ---
-
 
 ## 🛠 **Customization**
 

--- a/grafana/docker-compose.yaml
+++ b/grafana/docker-compose.yaml
@@ -1,0 +1,23 @@
+version: '3.8'
+
+services:
+  grafana:
+    image: grafana/grafana:latest
+    container_name: grafana
+    restart: always
+    ports:
+      - "3000:3000"
+    volumes:
+      - grafana_data:/var/lib/grafana
+    environment:
+      - GF_SECURITY_ADMIN_USER=admin
+      - GF_SECURITY_ADMIN_PASSWORD=admin
+    networks:
+      - grafana_network
+
+volumes:
+  grafana_data:
+
+networks:
+  grafana_network:
+    driver: bridge

--- a/n8n/docker-compose.yaml
+++ b/n8n/docker-compose.yaml
@@ -1,0 +1,24 @@
+version: '3.8'
+
+services:
+  n8n:
+    image: n8nio/n8n:latest
+    container_name: n8n
+    restart: always
+    ports:
+      - "5678:5678"
+    volumes:
+      - n8n_data:/home/node/.n8n
+    environment:
+      - N8N_BASIC_AUTH_ACTIVE=true
+      - N8N_BASIC_AUTH_USER=${N8N_USER:-admin}
+      - N8N_BASIC_AUTH_PASSWORD=${N8N_PASSWORD:-admin}
+    networks:
+      - n8n_network
+
+volumes:
+  n8n_data:
+
+networks:
+  n8n_network:
+    driver: bridge

--- a/prometheus/docker-compose.yaml
+++ b/prometheus/docker-compose.yaml
@@ -1,0 +1,21 @@
+version: '3.8'
+
+services:
+  prometheus:
+    image: prom/prometheus:latest
+    container_name: prometheus
+    restart: always
+    ports:
+      - "9090:9090"
+    volumes:
+      - prometheus_data:/prometheus
+      - ./prometheus.yml:/etc/prometheus/prometheus.yml
+    networks:
+      - prometheus_network
+
+volumes:
+  prometheus_data:
+
+networks:
+  prometheus_network:
+    driver: bridge

--- a/sentry/docker-compose.yaml
+++ b/sentry/docker-compose.yaml
@@ -1,0 +1,23 @@
+version: '3.8'
+
+services:
+  sentry:
+    image: getsentry/sentry:latest
+    container_name: sentry
+    restart: always
+    ports:
+      - "9000:9000"
+    volumes:
+      - sentry_data:/var/lib/sentry
+    environment:
+      - SENTRY_USER=${SENTRY_USER:-admin}
+      - SENTRY_PASSWORD=${SENTRY_PASSWORD:-admin}
+    networks:
+      - sentry_network
+
+volumes:
+  sentry_data:
+
+networks:
+  sentry_network:
+    driver: bridge


### PR DESCRIPTION
Add configurations for Grafana, Prometheus, n8n, and Sentry services using Docker Compose.

* **Grafana**:
  - Add `grafana/docker-compose.yaml` with Grafana service configuration.
  - Expose port `3000` for Grafana web UI.
  - Mount volume `grafana_data` to `/var/lib/grafana`.
  - Add environment variables for Grafana admin user and password.
  - Add network `grafana_network`.

* **Prometheus**:
  - Add `prometheus/docker-compose.yaml` with Prometheus service configuration.
  - Expose port `9090` for Prometheus web UI.
  - Mount volume `prometheus_data` to `/prometheus`.
  - Add configuration file `prometheus.yml` to `/etc/prometheus/prometheus.yml`.
  - Add network `prometheus_network`.

* **n8n**:
  - Add `n8n/docker-compose.yaml` with n8n service configuration.
  - Expose port `5678` for n8n web UI.
  - Mount volume `n8n_data` to `/home/node/.n8n`.
  - Add environment variables for n8n user and password.
  - Add network `n8n_network`.

* **Sentry**:
  - Add `sentry/docker-compose.yaml` with Sentry service configuration.
  - Expose port `9000` for Sentry web UI.
  - Mount volume `sentry_data` to `/var/lib/sentry`.
  - Add environment variables for Sentry user and password.
  - Add network `sentry_network`.

* **README.md**:
  - Add Grafana, Prometheus, n8n, and Sentry to the list of services.
  - Add brief descriptions for Grafana, Prometheus, n8n, and Sentry.
  - Add instructions for running Grafana, Prometheus, n8n, and Sentry.

