### PR TITLE
Add Docker Compose configurations for Airflow, Ollama, Deepseek AI, Notion, Elitist Search, and Slack

### DIFF
--- a/airflow/docker-compose.yaml
+++ b/airflow/docker-compose.yaml
@@ -1,0 +1,24 @@
+version: '3.8'
+
+services:
+  airflow:
+    image: apache/airflow:latest
+    container_name: airflow
+    restart: always
+    environment:
+      - AIRFLOW__CORE__EXECUTOR=LocalExecutor
+      - AIRFLOW__CORE__SQL_ALCHEMY_CONN=sqlite:////usr/local/airflow/airflow.db
+      - AIRFLOW__CORE__FERNET_KEY=your_fernet_key
+      - AIRFLOW__CORE__LOAD_EXAMPLES=False
+    ports:
+      - "8080:8080"
+    volumes:
+      - ./dags:/usr/local/airflow/dags
+      - ./logs:/usr/local/airflow/logs
+      - ./plugins:/usr/local/airflow/plugins
+    networks:
+      - airflow_network
+
+networks:
+  airflow_network:
+    driver: bridge

--- a/deepseek-ai/docker-compose.yaml
+++ b/deepseek-ai/docker-compose.yaml
@@ -1,0 +1,20 @@
+version: '3.8'
+
+services:
+  deepseek-ai:
+    image: deepseek/ai:latest
+    container_name: deepseek-ai
+    restart: always
+    environment:
+      - DEEPSEEK_AI_API_KEY=your_api_key
+      - DEEPSEEK_AI_ENV=production
+    ports:
+      - "6000:6000"
+    volumes:
+      - ./data:/var/lib/deepseek-ai
+    networks:
+      - deepseek_ai_network
+
+networks:
+  deepseek_ai_network:
+    driver: bridge

--- a/elitist-search/docker-compose.yaml
+++ b/elitist-search/docker-compose.yaml
@@ -1,0 +1,20 @@
+version: '3.8'
+
+services:
+  elitist-search:
+    image: elitist/search:latest
+    container_name: elitist-search
+    restart: always
+    environment:
+      - ELITIST_SEARCH_API_KEY=your_api_key
+      - ELITIST_SEARCH_ENV=production
+    ports:
+      - "8000:8000"
+    volumes:
+      - ./data:/var/lib/elitist-search
+    networks:
+      - elitist_search_network
+
+networks:
+  elitist_search_network:
+    driver: bridge

--- a/notion/docker-compose.yaml
+++ b/notion/docker-compose.yaml
@@ -1,0 +1,20 @@
+version: '3.8'
+
+services:
+  notion:
+    image: notion/notion:latest
+    container_name: notion
+    restart: always
+    environment:
+      - NOTION_API_KEY=your_api_key
+      - NOTION_ENV=production
+    ports:
+      - "7000:7000"
+    volumes:
+      - ./data:/var/lib/notion
+    networks:
+      - notion_network
+
+networks:
+  notion_network:
+    driver: bridge

--- a/ollama/docker-compose.yaml
+++ b/ollama/docker-compose.yaml
@@ -1,0 +1,20 @@
+version: '3.8'
+
+services:
+  ollama:
+    image: ollama/ollama:latest
+    container_name: ollama
+    restart: always
+    environment:
+      - OLLAMA_API_KEY=your_api_key
+      - OLLAMA_ENV=production
+    ports:
+      - "5000:5000"
+    volumes:
+      - ./data:/var/lib/ollama
+    networks:
+      - ollama_network
+
+networks:
+  ollama_network:
+    driver: bridge

--- a/slack/docker-compose.yaml
+++ b/slack/docker-compose.yaml
@@ -1,0 +1,20 @@
+version: '3.8'
+
+services:
+  slack:
+    image: slack/slack:latest
+    container_name: slack
+    restart: always
+    environment:
+      - SLACK_API_KEY=your_api_key
+      - SLACK_ENV=production
+    ports:
+      - "9000:9000"
+    volumes:
+      - ./data:/var/lib/slack
+    networks:
+      - slack_network
+
+networks:
+  slack_network:
+    driver: bridge


### PR DESCRIPTION
Fixes #2

Add Docker Compose configurations for Airflow, Ollama, Deepseek AI, Notion, Elitist Search, and Slack.

* **Airflow**
  - Add `airflow/docker-compose.yaml` with service configuration for Airflow.
  - Configure environment variables, ports, volumes, and network for Airflow.

* **Ollama**
  - Add `ollama/docker-compose.yaml` with service configuration for Ollama.
  - Configure environment variables, ports, volumes, and network for Ollama.

* **Deepseek AI**
  - Add `deepseek-ai/docker-compose.yaml` with service configuration for Deepseek AI.
  - Configure environment variables, ports, volumes, and network for Deepseek AI.

* **Notion**
  - Add `notion/docker-compose.yaml` with service configuration for Notion.
  - Configure environment variables, ports, volumes, and network for Notion.

* **Elitist Search**
  - Add `elitist-search/docker-compose.yaml` with service configuration for Elitist Search.
  - Configure environment variables, ports, volumes, and network for Elitist Search.

* **Slack**
  - Add `slack/docker-compose.yaml` with service configuration for Slack.
  - Configure environment variables, ports, volumes, and network for Slack.

