### PR TITLE
Add Minio Compose file

### DIFF
--- a/database/minio/.env.sample
+++ b/database/minio/.env.sample
@@ -1,0 +1,3 @@
+MINIO_TAG=latest
+MINIO_ROOT_USER=minioadmin
+MINIO_ROOT_PASSWORD=minioadmin

--- a/database/minio/docker-compose.yaml
+++ b/database/minio/docker-compose.yaml
@@ -1,0 +1,31 @@
+#
+#  * minio
+#  * author: @alisharify7
+#  * Under GPL-3.0 license.
+#  * email: alisharifyofficial@gmail.com
+#  * read more at repo: https://github.com/alisharify7/preconfigured-docker-compose
+
+services:
+  minio:
+    image: minio/minio:${MINIO_TAG:-latest}
+    container_name: minio
+    hostname: minio
+    ports:
+      - "9000:9000"
+      - "9001:9001"
+    volumes:
+      - minio_data:/data
+      - minio_config:/root/.minio
+    environment:
+      - MINIO_ROOT_USER=${MINIO_ROOT_USER}
+      - MINIO_ROOT_PASSWORD=${MINIO_ROOT_PASSWORD}
+    command: server /data --console-address ":9001"
+    networks:
+      - minio_network
+
+volumes:
+  minio_data:
+  minio_config:
+
+networks:
+  minio_network:


### PR DESCRIPTION
Fixes #9

Add Minio Compose file to the repository.

* **Add `database/minio/docker-compose.yaml`**
  - Define `minio` service with image `minio/minio:${MINIO_TAG:-latest}`
  - Set container name to `minio` and hostname to `minio`
  - Map ports `9000:9000` and `9001:9001`
  - Add volumes for `minio_data:/data` and `minio_config:/root/.minio`
  - Add environment variables for `MINIO_ROOT_USER` and `MINIO_ROOT_PASSWORD`
  - Add command to run Minio server in `server /data --console-address ":9001"`
  - Add `networks` section with `minio_network`
  - Add `volumes` section with `minio_data` and `minio_config`
  - Add `networks` section with `minio_network`

* **Add `database/minio/.env.sample`**
  - Add `MINIO_TAG` variable with default value `latest`
  - Add `MINIO_ROOT_USER` variable with default value `minioadmin`
  - Add `MINIO_ROOT_PASSWORD` variable with default value `minioadmin`

