### PR TITLE
Add Jupyter Notebook server compose

### DIFF
--- a/dev-tools/jupyter-notebook/.env.sample
+++ b/dev-tools/jupyter-notebook/.env.sample
@@ -1,0 +1,2 @@
+JUPYTER_TOKEN=mytoken
+JUPYTER_PASSWORD=mypassword

--- a/dev-tools/jupyter-notebook/docker-compose.yaml
+++ b/dev-tools/jupyter-notebook/docker-compose.yaml
@@ -1,0 +1,23 @@
+version: '3.8'
+
+services:
+  jupyter:
+    image: jupyter/base-notebook
+    container_name: jupyter
+    restart: always
+    ports:
+      - "8888:8888"
+    environment:
+      - JUPYTER_TOKEN=${JUPYTER_TOKEN:-mytoken}
+      - JUPYTER_PASSWORD=${JUPYTER_PASSWORD:-mypassword}
+    volumes:
+      - ./notebooks:/home/jovyan/work
+    networks:
+      - jupyter_network
+
+volumes:
+  jupyter_data:
+
+networks:
+  jupyter_network:
+    driver: bridge


### PR DESCRIPTION
Fixes #21

Add Jupyter Notebook server configuration using Docker Compose.

* **Add `docker-compose.yaml` file:**
  - Create a new `docker-compose.yaml` file in `dev-tools/jupyter-notebook`.
  - Define a service for Jupyter Notebook server using the `jupyter/base-notebook` image.
  - Map ports `8888:8888`.
  - Set environment variables for Jupyter Notebook token and password.
  - Mount a volume for notebooks.
  - Define a custom network for the Jupyter service.

* **Add `.env.sample` file:**
  - Create a new `.env.sample` file in `dev-tools/jupyter-notebook`.
  - Add environment variables for Jupyter Notebook token and password.

